### PR TITLE
Feature/cloudwatchimproved

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Tamr VM Terraform Module
 
-## v4.3.0 - December 16th 2021
+
+## v4.4.0 - December 20th 2021
+* Deprecates `s3_policy_arns` in favor of `additional_policy_arns`.
+* Permits the ability to create the cloudwatch log group and pass it to the shell script.
+
+## v4.3.0 - December 17th 2021
 * Adds `minimal-logs`example which allows the use of cloudwatch in an automated fashion.
 
 ## v4.2.0 - August 20th 2021

--- a/README.md
+++ b/README.md
@@ -53,11 +53,11 @@ No provider.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
+| additional\_policy\_arns | List of policy ARNs to be attached to Tamr VM IAM role. | `list(string)` | n/a | yes |
 | ami | The AMI to use for the EC2 instance | `string` | n/a | yes |
 | aws\_instance\_profile\_name | IAM Instance Profile to create | `string` | n/a | yes |
 | aws\_role\_name | IAM Role to create, and to which the policies will be attached | `string` | n/a | yes |
 | key\_name | The key name to attach to the EC2 instance for SSH access | `string` | n/a | yes |
-| s3\_policy\_arns | List of S3 policy ARNs to attach to Tamr role. | `list(string)` | n/a | yes |
 | subnet\_id | The subnet to create the EC2 instance in | `string` | n/a | yes |
 | vpc\_id | The ID of the VPC in which to attach the security group | `string` | n/a | yes |
 | arn\_partition | The partition in which the resource is located. A partition is a group of AWS Regions.<br>  Each AWS account is scoped to one partition.<br>  The following are the supported partitions:<br>    aws -AWS Regions<br>    aws-cn - China Regions<br>    aws-us-gov - AWS GovCloud (US) Regions | `string` | `"aws"` | no |
@@ -69,6 +69,7 @@ No provider.
 | instance\_type | The instance type to use for the EC2 instance | `string` | `"c5.9xlarge"` | no |
 | permissions\_boundary | ARN of the policy that will be used to set the permissions boundary for the IAM Role | `string` | `null` | no |
 | private\_ips | List of private IPs to assign to the ENI attached to the Tamr EC2 Instance | `list(string)` | `null` | no |
+| s3\_policy\_arns | [DEPRECATED] List of S3 policy ARNs to attach to Tamr role. | `list(string)` | `[]` | no |
 | security\_group\_ids | Security groups to associate with the ec2 instance | `list(string)` | `[]` | no |
 | tags | A map of tags to add to all resources. | `map(string)` | `{}` | no |
 | tamr\_emr\_cluster\_ids | List of IDs for Static EMR clusters | `list(string)` | `[]` | no |

--- a/examples/minimal-logs/cloudwatch.tf
+++ b/examples/minimal-logs/cloudwatch.tf
@@ -1,0 +1,4 @@
+resource "aws_cloudwatch_log_group" "tamr_log_group" {
+  name = format("%s-%s", var.name-prefix, "tamr_log_group")
+  tags = var.tags
+}

--- a/examples/minimal-logs/tamrvm.tf
+++ b/examples/minimal-logs/tamrvm.tf
@@ -20,10 +20,11 @@ module "tamr-vm" {
   aws_role_name               = format("%s-tamr-ec2-role", var.name-prefix)
   aws_instance_profile_name   = format("%s-tamr-ec2-instance-profile", var.name-prefix)
   aws_emr_creator_policy_name = format("%sEmrCreatorPolicy", var.name-prefix)
-  s3_policy_arns = [
-    module.s3-bucket.rw_policy_arn,
-    "arn:aws:iam::aws:policy/CloudWatchAgentServerPolicy"
+  additional_policy_arns = [
+   module.s3-bucket.rw_policy_arn,
+   "arn:aws:iam::aws:policy/CloudWatchAgentServerPolicy"
   ]
+  s3_policy_arns = []
   ami               = var.ami_id
   instance_type     = "r5.2xlarge"
   key_name          = var.key_name
@@ -33,7 +34,7 @@ module "tamr-vm" {
   bootstrap_scripts = [
 
     # NOTE: If you would like to use local scripts, you can use terraform's file() function
-    templatefile("./test-bootstrap-scripts/cloudwatch-install.sh", { region = data.aws_region.current.name, endpoint = module.endpoints.endpoints["logs"].dns_entry[0]["dns_name"], log_group = var.log_group, log_stream = var.log_stream }),
+    templatefile("./test-bootstrap-scripts/cloudwatch-install.sh", { region = data.aws_region.current.name, endpoint = module.endpoints.endpoints["logs"].dns_entry[0]["dns_name"], log_group = aws_cloudwatch_log_group.tamr_log_group.name }),
   ]
 
   security_group_ids = module.aws-sg.security_group_ids

--- a/examples/minimal-logs/tamrvm.tf
+++ b/examples/minimal-logs/tamrvm.tf
@@ -21,10 +21,10 @@ module "tamr-vm" {
   aws_instance_profile_name   = format("%s-tamr-ec2-instance-profile", var.name-prefix)
   aws_emr_creator_policy_name = format("%sEmrCreatorPolicy", var.name-prefix)
   additional_policy_arns = [
-   module.s3-bucket.rw_policy_arn,
-   "arn:aws:iam::aws:policy/CloudWatchAgentServerPolicy"
+    module.s3-bucket.rw_policy_arn,
+    "arn:aws:iam::aws:policy/CloudWatchAgentServerPolicy"
   ]
-  s3_policy_arns = []
+  s3_policy_arns    = []
   ami               = var.ami_id
   instance_type     = "r5.2xlarge"
   key_name          = var.key_name

--- a/examples/minimal-logs/test-bootstrap-scripts/cloudwatch-install.sh
+++ b/examples/minimal-logs/test-bootstrap-scripts/cloudwatch-install.sh
@@ -2,20 +2,7 @@
 os=$(awk -F= '/^NAME/{print $2}' /etc/os-release)
 
 case $os in
-        "\"Amazon Linux\"")
-              echo "********** Downloading Cloudwatch Agent **********"
-              curl https://s3.${region}.amazonaws.com/amazoncloudwatch-agent-${region}/amazon_linux/amd64/latest/amazon-cloudwatch-agent.rpm --output agent.rpm
-              if [[ $(ls -la | grep agent) ]];
-              then
-              echo "Cloudwatch agent installation file was found."
-              else
-              echo "Could not download the Cloudwatch agent installation file."
-              exit 1
-              fi
-              echo "********** Installing Cloudwatch Agent **********"
-              yum install -y ./agent.rpm ;;
-        "\"Red Hat Enterprise Linux\"")
-              pwd
+        "\"Amazon Linux\"" | "\"Red Hat Enterprise Linux\"")
               echo "********** Downloading Cloudwatch Agent **********"
               curl https://s3.${region}.amazonaws.com/amazoncloudwatch-agent-${region}/amazon_linux/amd64/latest/amazon-cloudwatch-agent.rpm --output agent.rpm
               if [[ $(ls -la | grep agent) ]];
@@ -105,17 +92,15 @@ echo " {
       }
   } " | tee cloudwatch-config.json
 
+  echo "********** Mounting Cloudwatch Agent config file to Cloduwatch Agent **********"
+  /opt/aws/amazon-cloudwatch-agent/bin/amazon-cloudwatch-agent-ctl -a fetch-config -m ec2 -s -c file:/opt/aws/amazon-cloudwatch-agent/etc/cloudwatch-config.json
+
 case $os in
-       "\"Amazon Linux\"")
-              echo "********** Mounting Cloudwatch Agent config file to Cloduwatch Agent **********"
-              /opt/aws/amazon-cloudwatch-agent/bin/amazon-cloudwatch-agent-ctl -a fetch-config -m ec2 -s -c file:/opt/aws/amazon-cloudwatch-agent/etc/cloudwatch-config.json
-              amazon-cloudwatch-agent-ctl -a start ;;
-       "\"Red Hat Enterprise Linux\"")
-              echo "********** Mounting Cloudwatch Agent config file to Cloduwatch Agent **********"
-              /opt/aws/amazon-cloudwatch-agent/bin/amazon-cloudwatch-agent-ctl -a fetch-config -m ec2 -s -c file:/opt/aws/amazon-cloudwatch-agent/etc/cloudwatch-config.json
+       "\"Amazon Linux\"" | "\"Red Hat Enterprise Linux\"")
+         echo "********** Starting Cloudwatch Agent **********"
               amazon-cloudwatch-agent-ctl -a start ;;
         "\"Ubuntu\"")
-              /opt/aws/amazon-cloudwatch-agent/bin/amazon-cloudwatch-agent-ctl -a fetch-config -m ec2 -s -c file:/opt/aws/amazon-cloudwatch-agent/etc/cloudwatch-config.json
+        echo "********** Starting Cloudwatch Agent **********"
               systemctl start amazon-cloudwatch-agent.service ;;
         *)    echo "Not recognized OS, aborting..."
 

--- a/examples/minimal-logs/test-bootstrap-scripts/cloudwatch-install.sh
+++ b/examples/minimal-logs/test-bootstrap-scripts/cloudwatch-install.sh
@@ -54,49 +54,49 @@ echo " {
                      {
                          \"file_path\": \"/home/ubuntu/tamr/logs/unify-all.error.log\",
                          \"log_group_name\": \"${log_group}\",
-                         \"log_stream_name\": \"${log_stream}\",
+                         \"log_stream_name\": \"unify\",
                          \"timestamp_format\": \"%H: %M: %S%y%b%-d\"
                      },
                      {
                          \"file_path\": \"/home/ubuntu/tamr/logs/unify-all.out.log\",
                          \"log_group_name\": \"${log_group}\",
-                         \"log_stream_name\": \"${log_stream}\",
+                         \"log_stream_name\": \"unify\",
                          \"timestamp_format\": \"%H: %M: %S%y%b%-d\"
                      },
                      {
                          \"file_path\": \"/home/ubuntu/tamr/logs/unify-events.log\",
                          \"log_group_name\": \"${log_group}\",
-                         \"log_stream_name\": \"${log_stream}\",
+                         \"log_stream_name\": \"unify\",
                          \"timestamp_format\": \"%H: %M: %S%y%b%-d\"
                      },
                      {
                          \"file_path\": \"/home/ubuntu/tamr/logs/unify.log\",
                          \"log_group_name\": \"${log_group}\",
-                         \"log_stream_name\": \"${log_stream}\",
+                         \"log_stream_name\": \"unify\",
                          \"timestamp_format\": \"%H: %M: %S%y%b%-d\"
                      },
                      {
                          \"file_path\": \"/home/ubuntu/tamr/logs/auth.log\",
                          \"log_group_name\": \"${log_group}\",
-                         \"log_stream_name\": \"${log_stream}\",
+                         \"log_stream_name\": \"unify-auth\",
                          \"timestamp_format\": \"%H: %M: %S%y%b%-d\"
                      },
                      {
                          \"file_path\": \"/home/ubuntu/tamr/logs/dataset.log\",
                          \"log_group_name\": \"${log_group}\",
-                         \"log_stream_name\": \"${log_stream}\",
+                         \"log_stream_name\": \"unify-dataset\",
                          \"timestamp_format\": \"%H: %M: %S%y%b%-d\"
                      },
                      {
                          \"file_path\": \"/home/ubuntu/tamr/logs/recipe.log\",
                          \"log_group_name\": \"${log_group}\",
-                         \"log_stream_name\": \"${log_stream}\",
+                         \"log_stream_name\": \"unify-recipe\",
                          \"timestamp_format\": \"%H: %M: %S%y%b%-d\"
                      },
                      {
                          \"file_path\": \"/home/ubuntu/tamr/logs/dedup.log\",
                          \"log_group_name\": \"${log_group}\",
-                         \"log_stream_name\": \"${log_stream}\",
+                         \"log_stream_name\": \"unify-dedup\",
                          \"timestamp_format\": \"%H: %M: %S%y%b%-d\"
                      }
                  ]

--- a/examples/minimal/tamrvm.tf
+++ b/examples/minimal/tamrvm.tf
@@ -25,7 +25,7 @@ module "tamr-vm" {
   aws_role_name               = format("%s-tamr-ec2-role", var.name-prefix)
   aws_instance_profile_name   = format("%s-tamr-ec2-instance-profile", var.name-prefix)
   aws_emr_creator_policy_name = format("%sEmrCreatorPolicy", var.name-prefix)
-  s3_policy_arns = [
+  additional_policy_arns = [
     module.s3-bucket.rw_policy_arn,
   ]
   ami               = var.ami_id

--- a/main.tf
+++ b/main.tf
@@ -1,3 +1,7 @@
+locals {
+  effective_policy_arns = length(var.s3_policy_arns) > 0 ? var.s3_policy_arns : var.additional_policy_arns
+}
+
 //working example for Tamr EMR account
 module "aws-iam-role" {
   source                    = "./modules/aws-iam-role"
@@ -11,7 +15,7 @@ module "aws-iam-policies" {
   source                      = "./modules/aws-iam-policies"
   aws_role_name               = module.aws-iam-role.tamr_instance_role_name
   aws_emr_creator_policy_name = var.aws_emr_creator_policy_name
-  s3_policy_arns              = var.s3_policy_arns
+  additional_policy_arns      = local.effective_policy_arns
   tamr_emr_cluster_ids        = var.tamr_emr_cluster_ids
   tamr_emr_role_arns          = var.tamr_emr_role_arns
   tags                        = var.tags

--- a/modules/aws-iam-policies/README.md
+++ b/modules/aws-iam-policies/README.md
@@ -39,8 +39,8 @@ This modules creates:
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
+| additional\_policy\_arns | List of policy ARNs to be attached to Tamr VM IAM role. | `list(string)` | n/a | yes |
 | aws\_role\_name | IAM Role to which the policy will be attached | `string` | n/a | yes |
-| s3\_policy\_arns | List of S3 policy ARNs to attach to Tamr role. | `list(string)` | n/a | yes |
 | arn\_partition | The partition in which the resource is located. A partition is a group of AWS Regions.<br>  Each AWS account is scoped to one partition.<br>  The following are the supported partitions:<br>    aws -AWS Regions<br>    aws-cn - China Regions<br>    aws-us-gov - AWS GovCloud (US) Regions | `string` | `"aws"` | no |
 | aws\_emr\_creator\_policy\_name | The name to give to the policy regarding EMR permissions | `string` | `"emrCreatorMinimalPolicy"` | no |
 | emr\_abac\_valid\_tags | Valid tags for maintaining EMR resources when using ABAC IAM Policies with Tag Conditions. | `map(list(string))` | `{}` | no |
@@ -52,8 +52,8 @@ This modules creates:
 
 | Name | Description |
 |------|-------------|
+| additional\_policy\_arns | List of policy ARNs to be attached to Tamr VM IAM role. |
 | emr\_creator\_policy\_arn | ARN of the EMR creator IAM policy created. |
-| s3\_policy\_arns | List of ARNs of S3 policies attached to Tamr user IAM role |
 
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 

--- a/modules/aws-iam-policies/main.tf
+++ b/modules/aws-iam-policies/main.tf
@@ -1,7 +1,6 @@
 locals {
   arn_prefix_elasticmapreduce = "arn:${var.arn_partition}:elasticmapreduce:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}"
 }
-
 /*
 reduced permissions role for EMR. Some permissions can be limited to clusters,
 while others must have access to all EMR in order to operate correctly.
@@ -96,9 +95,9 @@ resource "aws_iam_role_policy_attachment" "emr_creator_policy_attachment" {
   policy_arn = aws_iam_policy.emr_creator_minimal_policy.arn
 }
 
-// IAM role policy attachment(s) that attach s3 policy ARNs to Tamr user IAM role
-resource "aws_iam_role_policy_attachment" "emrfs_user_s3_policy" {
-  count      = length(var.s3_policy_arns)
+// IAM role policy attachment(s) that attach additional policy ARNs to Tamr user IAM role
+resource "aws_iam_role_policy_attachment" "additional_user_policies" {
+  count      = length(var.additional_policy_arns)
   role       = var.aws_role_name
-  policy_arn = element(var.s3_policy_arns, count.index)
+  policy_arn = element(var.additional_policy_arns, count.index)
 }

--- a/modules/aws-iam-policies/outputs.tf
+++ b/modules/aws-iam-policies/outputs.tf
@@ -3,7 +3,7 @@ output "emr_creator_policy_arn" {
   description = "ARN of the EMR creator IAM policy created."
 }
 
-output "s3_policy_arns" {
-  value       = var.s3_policy_arns
-  description = "List of ARNs of S3 policies attached to Tamr user IAM role"
+output "additional_policy_arns" {
+  value       = var.additional_policy_arns
+  description = "List of policy ARNs to be attached to Tamr VM IAM role."
 }

--- a/modules/aws-iam-policies/variables.tf
+++ b/modules/aws-iam-policies/variables.tf
@@ -9,9 +9,9 @@ variable "aws_role_name" {
   description = "IAM Role to which the policy will be attached"
 }
 
-variable "s3_policy_arns" {
+variable "additional_policy_arns" {
   type        = list(string)
-  description = "List of S3 policy ARNs to attach to Tamr role."
+  description = "List of policy ARNs to be attached to Tamr VM IAM role."
 }
 
 variable "arn_partition" {

--- a/variables.tf
+++ b/variables.tf
@@ -17,7 +17,7 @@ variable "aws_instance_profile_name" {
 variable "s3_policy_arns" {
   type        = list(string)
   description = "[DEPRECATED] List of S3 policy ARNs to attach to Tamr role."
-  default = []
+  default     = []
 }
 
 variable "additional_policy_arns" {

--- a/variables.tf
+++ b/variables.tf
@@ -16,7 +16,13 @@ variable "aws_instance_profile_name" {
 
 variable "s3_policy_arns" {
   type        = list(string)
-  description = "List of S3 policy ARNs to attach to Tamr role."
+  description = "[DEPRECATED] List of S3 policy ARNs to attach to Tamr role."
+  default = []
+}
+
+variable "additional_policy_arns" {
+  type        = list(string)
+  description = "List of policy ARNs to be attached to Tamr VM IAM role."
 }
 
 variable "arn_partition" {


### PR DESCRIPTION
* Deprecates `s3_policy_arns` in favor of `additional_policy_arns`.
* Permits the ability to create the cloudwatch log group and pass it to the shell script.